### PR TITLE
Use uart0 for midi and uart1 for debug messages

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -1,8 +1,9 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-#ifdef DEBUG_ESP_PORT
-#define DEBUG_MSG(...) DEBUG_ESP_PORT.printf( __VA_ARGS__ )
+#ifdef DEBUG
+#define DEBUG_ESP_PORT Serial1
+#define DEBUG_MSG(...) Serial1.printf( __VA_ARGS__ )
 #else
 #define DEBUG_MSG(...)
 #endif

--- a/src/OSC2Midi.cpp
+++ b/src/OSC2Midi.cpp
@@ -1,13 +1,12 @@
+#include "debug.h"
 #include <Arduino.h>
 #include <ESP8266WiFi.h>
 #include <WiFiUdp.h>
 #include <OSCMessage.h>
 #include <OSCBundle.h>
 #include <OSCData.h>
-#include <SoftwareSerial.h>
 #include <MIDI.h>
 #include <OSC2Midi.h>
-#include "debug.h"
 
 void MidiCCToOSC(uint8_t channel, uint8_t number, uint8_t value);
 
@@ -18,22 +17,14 @@ WiFiUDP udp;
 */
 IPAddress clientIP;
 
-SoftwareSerial midiSerialPort(4, 5); // RX, TX pins to be used for ss port
-
-MIDI_CREATE_INSTANCE(SoftwareSerial, midiSerialPort, MIDI);
-
-// Built-in led used to show activity status
-#define LED_BUILTIN 2
-bool led = false;
+ MIDI_CREATE_INSTANCE(HardwareSerial, Serial, MIDI);
 
 void setup() {
-  // The MIDI input used in project is always pulled high,
-  // so don't try to "fight" and pull the input pin up as well
-  pinMode(4, INPUT_PULLUP);
-  pinMode(5, OUTPUT);
-  pinMode(LED_BUILTIN, OUTPUT);
-
-  Serial.begin(115200);
+#ifdef DEBUG
+  // Debug via UART1 TX only
+  Serial1.begin(115200, SERIAL_8N1, SERIAL_TX_ONLY, 2);
+  Serial1.setDebugOutput(true);
+#endif
 
   DEBUG_MSG("\nHello OSC2Midi!\n");
 
@@ -43,9 +34,9 @@ void setup() {
 
   udp.begin(8000);
 
+  // Midi via UART0
+  Serial.begin(31250);
   MIDI.setHandleControlChange(MidiCCToOSC);
-
-  midiSerialPort.begin(31250);
 }
 
 void OSCToMidiCC(OSCMessage &msg, int offset) {
@@ -105,8 +96,6 @@ void loop() {
 
     if (!msg.hasError()) {
       msg.route("/midi/cc", OSCToMidiCC);
-      led = !led;
-      digitalWrite(LED_BUILTIN, led);
     } else {
       DEBUG_MSG("Error parsing OSC message: %d", msg.getError());
     }


### PR DESCRIPTION
This ditches SoftwareSerial for which I suspect was causing crashes.
This also ditches led blinking since built-in esp12e led is on the same pin as
uart1 tx.